### PR TITLE
[fix] Fix styles merging

### DIFF
--- a/spec/shared_examples_for_tags_with_styles.rb
+++ b/spec/shared_examples_for_tags_with_styles.rb
@@ -183,16 +183,11 @@ shared_examples_for "tags with styles" do |tag, element_on_fdx|
     end
   end
 
-  # TODO: we have to ensure we handle "**b****xb***i*" as "**b**" "**xb**" "*i*"
-  # maybe we can use a fountain with "<b><i><u>" when we need to export to FDX
   context 'when a word has a mix of formatting' do
-    let(:element_text_on_fountain) { '**b****xb***i*' }
-    let(:bold) { %r{.*<Text Style="Bold">\(?b</Text>.*} }
-    let(:inner_bold) { %r{.*<Text Style="Bold">xb</Text>.*} }
-    let(:italic) { %r{.*<Text Style="Italic">i\)?</Text>.*} }
-    let(:result) { %r{#{bold}#{inner_bold}#{italic}} }
+    let(:element_text_on_fountain) { '***_iub_***' }
+    let(:result) { %r{.*<Text Style="Bold\+Italic\+Underline">\(?iub\)?</Text>.*} }
 
-    xit 'returns the the tag with the right formatting' do
+    it 'returns the the tag with the right formatting' do
       expect(subject).to match result
     end
   end

--- a/textplay
+++ b/textplay
@@ -1068,6 +1068,32 @@ def ensure_content_is_wrapped_on_text_tag(text)
   return "#{ensure_content_is_wrapped_on_text_tag(m.pre_match)}#{m}#{ensure_content_is_wrapped_on_text_tag(m.post_match)}"
 end
 
+def merge_multiple_styles(text)
+  return text if text.empty?
+  output = text
+
+  regex_multiple_styles = /(?:<Text\sStyle="(?:Bold|Italic|Underline)">){2,}(?:.*?)(?:<\/Text>){2,}/
+  regex_inner_content   = /(?:<Text\sStyle="(?:Bold|Italic|Underline)">){2,}(.*?)(?:<\/Text>){2,}/
+
+  text_with_multiple_styles = text.scan(regex_multiple_styles)
+  return output if text_with_multiple_styles.empty?
+
+  text_with_multiple_styles.each do |match|
+    # get styles
+    styles = match.scan(/<Text\sStyle="(Bold|Italic|Underline)+">/).join("+")
+
+    # get inner content
+    inner_content = match.scan(regex_inner_content).join
+
+    # merge styles
+    merged_styles = "<Text Style=\"#{styles}\">#{inner_content}</Text>"
+    output.gsub!(match, merged_styles)
+  end
+
+  output
+end
+
+
 # NOTE: PHASE 5 - Convert XML to requested format
 # -----------------------------------------------------------------------------
 
@@ -1085,6 +1111,7 @@ if options[:fdx] == true
   text = text.gsub(/<\/u>/, '</Text>')
   text = text.gsub(/<i>/, '<Text Style="Italic">')
   text = text.gsub(/<\/i>/, '</Text>')
+  text = merge_multiple_styles(text)
   text = ensure_content_is_wrapped_on_text_tag(text)
   text = text.gsub(/<page-break \/>/, '<Paragraph Type="Action" StartsNewPage="Yes"><Text></Text></Paragraph>')
   text = text.gsub(/<transition>/, '<Paragraph Type="Transition"><Text>')


### PR DESCRIPTION
This PR changes the way how we parse text with multiple styles (bold `**`, italic `*`, and underline `_`).

Given the input in Fountain syntax
```
***_hello world_***
```
which can be understood as in this XML expression
```
<bold><italic><underline>hello world</underline></italic></bold>
```
the Textplay was producing the wrong FDX output
```
<Text Style="Bold"><Text Style="Italic"><Text Style="Underline">Hello World</Text></Text></Text>
```
Now, the right output is
```
<Text Style="Bold+Italic+Underline">Hello World</Text>
```


Implements part of the [card 2234](https://trello.com/c/p4DOxujR).