### PR TITLE
[fix] Does not escape '--'

### DIFF
--- a/spec/general_spec.rb
+++ b/spec/general_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'shared_examples_for_tags_with_styles'
+
+describe 'general' do
+  subject { convert_from_fountain_to_fdx(fountain) }
+  let(:tag) { 'General' }
+  let(:inner_text) { 'general' }
+  let(:element_text_on_fountain) { "#{inner_text}" }
+  let(:general_text) { inner_text }
+  let(:fountain) { element_text_on_fountain }
+  let(:fdx_result) { fdx_tag_with_content(tag, general_text) }
+
+  it 'returns the fdx general type' do
+    expect(subject).to match fdx_result
+  end
+
+  # this is the same behavior for other tags too
+  it "does not wrap file content on a <Text>" do
+    expect(subject).not_to match %r{<Content>\n*<Text>}
+    expect(subject).not_to match %r{</Text>\n*</Content>}
+  end
+
+  context "when text contains '--'" do
+    let(:general_text) { 'Line with - -- --- ---' }
+    let(:inner_text) { "#{general_text}" }
+
+    it "returns the text without escape the '--'" do
+      expect(subject).to match fdx_result
+    end
+  end
+
+  it_behaves_like 'tags with styles', 'General', 'general'
+end

--- a/textplay
+++ b/textplay
@@ -822,7 +822,7 @@ end
 # Misc Encoding
 text = text.gsub(/^[ \t]*([=-]{3,})[ \t]*({{%}})?$/, '<page-break />')
 text = text.gsub(/&/, '&#38;')
-text = text.gsub(/([^-])--([^-])/, '\1&#8209;&#8209;\2')
+#text = text.gsub(/([^-])--([^-])/, '\1&#8209;&#8209;\2') # We think it's not necessary
 text = text.gsub(/^[ \t]+$/, '')
 text = text.gsub(/</, '&#60;')
 text = text.gsub(/>/, '&#62;')

--- a/textplay
+++ b/textplay
@@ -822,7 +822,7 @@ end
 # Misc Encoding
 text = text.gsub(/^[ \t]*([=-]{3,})[ \t]*({{%}})?$/, '<page-break />')
 text = text.gsub(/&/, '&#38;')
-#text = text.gsub(/([^-])--([^-])/, '\1&#8209;&#8209;\2') # We think it's not necessary
+#text = text.gsub(/([^-])--([^-])/, '\1&#8209;&#8209;\2') # We think it's not necessary once <> is already escaped.
 text = text.gsub(/^[ \t]+$/, '')
 text = text.gsub(/</, '&#60;')
 text = text.gsub(/>/, '&#62;')


### PR DESCRIPTION
This PR removes the escaping of `--`. After some analysis, we concluded that this procedure is not necessary. The related source code has been commented on to help future problems that this change might introduce.

Given the input in Fountain syntax
```
Line with - -- --- ----
```
the Textplay was producing the wrong FDX output
```
<Paragraph Type="General"><Text>Line with - &#8209;&#8209; --- ----</Text></Paragraph>
```
Now, the right output is
```
<Paragraph Type="General"><Text>Line with - -- --- ----</Text></Paragraph>
```


### Extra work

This PR also adds the missing `general` spec.

Implements part of the [card 2234](https://trello.com/c/p4DOxujR).