### PR TITLE
[feat] Exports Shot elements

### DIFF
--- a/spec/shot_spec.rb
+++ b/spec/shot_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'shared_examples_for_tags_with_styles'
+
+describe 'shot' do
+  subject { convert_from_fountain_to_fdx(fountain) }
+  let(:tag) { 'Shot' }
+  let(:inner_text) { 'SHOT' }
+  let(:element_text_on_fountain) { "!/*SHOT*/#{inner_text}" }
+  let(:shot_text) { inner_text }
+  let(:fountain) { element_text_on_fountain }
+  let(:fdx_result) { fdx_tag_with_content(tag, shot_text) }
+
+  it 'returns the fdx shot type' do
+    expect(subject).to match fdx_result
+  end
+
+  # this is the same behavior for other tags too
+  it "does not wrap file content on a <Text>" do
+    expect(subject).not_to match %r{<Content>\n*<Text>}
+    expect(subject).not_to match %r{</Text>\n*</Content>}
+  end
+
+  it_behaves_like 'tags with styles', 'Shot', 'SHOT'
+end

--- a/textplay
+++ b/textplay
@@ -796,8 +796,8 @@ text = text.gsub(/\u0008/, "")
 # They must also be removed so they don't interfere with the transformation
 # of adjacent elements.
 
-# Boneyard
-text = text.gsub(/\/\*(.|\n)+?\*\//, '')
+# Boneyard, excluding /*SHOT*/ marks
+text = text.gsub(/(?!\/\*SHOT\*\/)\/\*(.|\n)+?\*\//, '')
 
 # Fountain [[notes]]
 text = text.gsub(/\[{2}[^\]]+\]{2}/,'')
@@ -830,6 +830,9 @@ text = text.gsub(/\\\_/, '&#95;')
 text = text.gsub(/\\\*/, '&#42;')
 
 # -------- fountain escapes
+
+# Shot escape
+text = text.gsub(/^\!\/\*SHOT\*\/(.+)/, '<shot>\1</shot>')
 
 # Action escape
 text = text.gsub(/^\!(.+)/, '<action>\1</action>')
@@ -1129,6 +1132,8 @@ if options[:fdx] == true
   text = text.gsub(/<\/talk>/, '</Text></Paragraph>')
   text = text.gsub(/<action>/, '<Paragraph Type="Action"><Text>')
   text = text.gsub(/<\/action>/, '</Text></Paragraph>')
+  text = text.gsub(/<shot>/, '<Paragraph Type="Shot"><Text>')
+  text = text.gsub(/<\/shot>/, '</Text></Paragraph>')
   text = text.gsub(/<general>/, '<Paragraph Type="General"><Text>')
   text = text.gsub(/<\/general>/, '</Text></Paragraph>')
 
@@ -1169,6 +1174,8 @@ else
   text = text.gsub(/<\/lyric>/, '</span>')
   text = text.gsub(/<action>/, '<p class="action">')
   text = text.gsub(/<\/action>/, '</p>')
+  text = text.gsub(/<shot>/, '<p class="shot">')
+  text = text.gsub(/<\/shot>/, '</p>')
   text = text.gsub(/<revised>/, '<span class="revised">')
   text = text.gsub(/<\/revised>/, '</span>')
 end


### PR DESCRIPTION
Shot elements are not recognized by Fountain. For having these elements on FDX, we parse Actions with a specific mark `/*SHOT*/` into Shot elements. Eg.:

**Fountain**
```fountain
!This is an Action
!/*SHOT*/THIS IS A SHOT
```

**FDX**
```xml
<Paragraph Type="Action"><Text>This is an Action</Text></Paragraph>
<Paragraph Type="Shot"><Text>THIS IS A SHOT</Text></Paragraph>
```

Implements the [card 2400](https://trello.com/c/TOB4ByEy).