### PR TITLE
[feat] Apply FDX styles

### DIFF
--- a/textplay
+++ b/textplay
@@ -758,15 +758,73 @@ htmlEnd = '
 </html>
 '
 
+# Final Draft's Style
+fdxStyle = '
+<ElementSettings Type="General">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style=""/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="1.50" RightIndent="7.50" SpaceBefore="0" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="General" ReturnKey="General" Shortcut="0"/>
+</ElementSettings>
+
+<ElementSettings Type="Scene Heading">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style="AllCaps"/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="1.50" RightIndent="7.50" SpaceBefore="24" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Scene Heading" ReturnKey="Action" Shortcut="1"/>
+</ElementSettings>
+
+<ElementSettings Type="Action">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style=""/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="1.50" RightIndent="7.50" SpaceBefore="12" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Action" ReturnKey="Action" Shortcut="2"/>
+</ElementSettings>
+
+<ElementSettings Type="Character">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style="AllCaps"/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="3.50" RightIndent="7.25" SpaceBefore="12" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Character" ReturnKey="Dialogue" Shortcut="3"/>
+</ElementSettings>
+
+<ElementSettings Type="Parenthetical">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style=""/>
+<ParagraphSpec Alignment="Left" FirstIndent="-0.10" Leading="Regular" LeftIndent="3.00" RightIndent="5.50" SpaceBefore="0" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Parenthetical" ReturnKey="Dialogue" Shortcut="4"/>
+</ElementSettings>
+
+<ElementSettings Type="Dialogue">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style=""/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="2.50" RightIndent="6.00" SpaceBefore="0" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Dialogue" ReturnKey="Action" Shortcut="5"/>
+</ElementSettings>
+
+<ElementSettings Type="Transition">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style="AllCaps"/>
+<ParagraphSpec Alignment="Right" FirstIndent="0.00" Leading="Regular" LeftIndent="5.50" RightIndent="7.10" SpaceBefore="12" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Transition" ReturnKey="Scene Heading" Shortcut="6"/>
+</ElementSettings>
+
+<ElementSettings Type="Shot">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style="AllCaps"/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="1.50" RightIndent="7.50" SpaceBefore="24" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Scene Heading" ReturnKey="Action" Shortcut="7"/>
+</ElementSettings>
+
+<ElementSettings Type="Cast List">
+<FontSpec AdornmentStyle="0" Background="#FFFFFFFFFFFF" Color="#000000000000" Font="Courier Final Draft" RevisionID="0" Size="12" Style="AllCaps"/>
+<ParagraphSpec Alignment="Left" FirstIndent="0.00" Leading="Regular" LeftIndent="1.50" RightIndent="7.50" SpaceBefore="0" Spacing="1" StartsNewPage="No"/>
+<Behavior PaginateAs="Action" ReturnKey="Action" Shortcut="8"/>
+</ElementSettings>
+'
+
 # Final Draft's XML header
 fdxStart = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <FinalDraft DocumentType="Script" Template="No" Version="1">
 <Content>
 '
 # Final Draft's XML footer
-fdxEnd = '</Content>
+fdxEnd = "</Content>
+#{fdxStyle}
 </FinalDraft>
-'
+"
 
 # XML Header
 xmlStart = '<?xml version="1.0" encoding="UTF-8" standalone="no" ?>


### PR DESCRIPTION
This PR adds some Final Draft styles in the output XML that affects elements like `General`, `Scene Heading`, `Action`, `Character`, `Parenthetical`, `Dialogue`, `Transition`, `Shot` and `Cast List`. These styles were copied from XML exported by Final Draft.

Implements the [card 2197](https://trello.com/c/RsbI9CpE).