### PR TITLE
[fix] Fix SHOT parsing

### DIFF
--- a/spec/shot_spec.rb
+++ b/spec/shot_spec.rb
@@ -5,7 +5,7 @@ describe 'shot' do
   subject { convert_from_fountain_to_fdx(fountain) }
   let(:tag) { 'Shot' }
   let(:inner_text) { 'SHOT' }
-  let(:element_text_on_fountain) { "!/*SHOT*/#{inner_text}" }
+  let(:element_text_on_fountain) { "/*SHOT*/!#{inner_text}" }
   let(:shot_text) { inner_text }
   let(:fountain) { element_text_on_fountain }
   let(:fdx_result) { fdx_tag_with_content(tag, shot_text) }

--- a/textplay
+++ b/textplay
@@ -890,7 +890,7 @@ text = text.gsub(/\\\*/, '&#42;')
 # -------- fountain escapes
 
 # Shot escape
-text = text.gsub(/^\!\/\*SHOT\*\/(.+)/, '<shot>\1</shot>')
+text = text.gsub(/^\/\*SHOT\*\/\!(.+)/, '<shot>\1</shot>')
 
 # Action escape
 text = text.gsub(/^\!(.+)/, '<action>\1</action>')


### PR DESCRIPTION
It was necessary to modify the boneyard position to allow parsing SHOTs with styles (bold, italic, underline).

It is related to the [card 2400](https://trello.com/c/TOB4ByEy).