### PR TITLE
[chore] Disables goldman-sluglines by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ See ``--help`` for info.
 Key                                      Default Value
 =======================================  ==================
 title                                    "A Screenplay"
-goldman_sluglines                        on
+goldman_sluglines                        off
 screenbundle_comments                    off
 font                                     "Courier Prime"
 slugline_spacing (number of 12pt lines)  1

--- a/textplay
+++ b/textplay
@@ -159,7 +159,7 @@ be customized:
 
       You can define what name textplay uses when generating files.
 
-    * goldman_sluglines (on/off) -- default: on
+    * goldman_sluglines (on/off) -- default: off
 
       By default textplay interprets any line that's all-caps as a
       slugline.
@@ -216,7 +216,7 @@ document like this:
 
 title: Ron's Woodland Adventure
 font: Courier New
-goldman_sluglines: off
+goldman_sluglines: on
 bold_sluglines: on
 
 The block of key/value pairs:
@@ -429,7 +429,7 @@ if title == nil or title == ""
 end
 
 if goldman_sluglines == nil or goldman_sluglines == ""
-goldman_sluglines = "on"
+goldman_sluglines = "off"
 end
 
 if screenbundle_comments == nil or screenbundle_comments == ""


### PR DESCRIPTION
This PR sets the `goldman-sluglines` option as `off` by default.
It prevents parsing uppercase Generals into Headings.

Implements part of the [card 2432](https://trello.com/c/j4SkmGHC).