### PR TITLE
[fix] Parsing Dialogues at the EOF

### DIFF
--- a/spec/dialogue_spec.rb
+++ b/spec/dialogue_spec.rb
@@ -33,4 +33,17 @@ describe 'dialogue' do
       expect(subject).to match fdx_result
     end
   end
+
+  context 'when there is no new line after the dialogue (EOF)' do
+    let(:fountain) do
+      <<-FOUNTAIN.chomp # chomp avoids the last \n on HEREDOC syntax
+        \nVITO CORLEONE
+        #{element_text_on_fountain}
+      FOUNTAIN
+    end
+
+    it 'returns the fdx dialogue type' do
+      expect(subject).to match fdx_result
+    end
+  end
 end

--- a/textplay
+++ b/textplay
@@ -974,10 +974,13 @@ text = text.gsub(/
 # Optional revision marker
 ({{%}})?\n
 # Dialogue
-(^[\ \t]* .+ \n)+
+(^[\ \t]* .+ \n?)+
 # Require trailing empty line or end of document
 (^[\ \t]*$|\Z)
 /x, "\n"+'<dialogue>'+'\0'+'</dialogue>'+"\n")
+
+# Forces the dialog closing marker to be alone on a new line.
+text = text.gsub(/(.)<\/dialogue>$/, '\1' + "\n" + '</dialogue>')
 
 # Now that they're wrapped, tag the individual elements
 


### PR DESCRIPTION
When there is no new line after a Dialog, that is, when a Dialog is at the end of the file (EOF), it was parsed into General. This PR fixes this case.

Implements part of the [card 2432](https://trello.com/c/j4SkmGHC).