### PR TITLE
[feat] Allows to set the fallback element type

### DIFF
--- a/spec/fallback_spec.rb
+++ b/spec/fallback_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'shared_examples_for_tags_with_styles'
+
+describe 'fallback' do
+  subject { convert_from_fountain_to_fdx(fountain, cmd_options) }
+  let(:fountain) { 'text without type' }
+
+  context "when no fallback is specified" do
+    let(:cmd_options) { ['-f'] }
+
+    it 'used GENERAL as fallback' do
+      expect(subject).to match fdx_tag_with_content('General', fountain)
+    end
+  end
+
+  context "when a fallback is specified" do
+    let(:fallback_element) { 'action' }
+    let(:cmd_options) { ['-f', "--fallback=#{fallback_element}"] }
+
+    it 'used the given fallback element' do
+      expect(subject).to match fdx_tag_with_content('Action', fountain)
+    end
+  end
+end

--- a/spec/test_helpers.rb
+++ b/spec/test_helpers.rb
@@ -1,10 +1,10 @@
 require 'open3'
 
 module TestHelpers
-  CONVERT_COMMAND = 'textplay -f'.freeze
+  CONVERT_COMMAND = 'textplay'.freeze
 
-  def convert_from_fountain_to_fdx(fountain_data)
-    Open3.capture2(CONVERT_COMMAND, stdin_data: fountain_data)[0]
+  def convert_from_fountain_to_fdx(fountain_data, cmd_options = ['-f'])
+    Open3.capture2("#{CONVERT_COMMAND} #{cmd_options.join(" ")}", stdin_data: fountain_data)[0]
   end
 
   def fdx_tag_with_content(tag, inner_content)

--- a/textplay
+++ b/textplay
@@ -69,12 +69,17 @@ Usage: textplay [options]
 		options[:wrap] = true
 	end
 
-  # if the '-e' option is set grab fountain header and export it to fdx
-  options[:fountain_header] = false
-  opts.on( '-e', '--fheader', "Look for fountain header and export it" ) do
-    options[:fountain_header] = true
-  end
+	# if the '-e' option is set grab fountain header and export it to fdx
+	options[:fountain_header] = false
+	opts.on( '-e', '--fheader', "Look for fountain header and export it" ) do
+		options[:fountain_header] = true
+	end
 
+	# The default fallback element is 'general'. This option can change it (eg: --fallback=action)
+	options[:fallback_element] = 'general'
+	opts.on( '-F', '--fallback ELEMENT', String, "Any untagged paragraph gets tagged as 'element' (default 'general')" ) do |fallback_element|
+		options[:fallback_element] = fallback_element
+	end
 end
 
 # Parse the options and remove them from ARGV
@@ -86,13 +91,14 @@ TEXTPLAY
 
     textplay [options]
 
-    -h, --help        Display the help text
-    -s, --snippet     Do not include document headers/footers
-    -f, --fdx         Convert to Final Draft .fdx
-    -x, --xml         Output as the internal raw XML
-    -d, --diff        Assume input is a diff, generate revision marks
-    -w, --wrap        Wrap action and dialogue paragraphs
-    -e, --fheader     Look for fountain header and export it
+    -h, --help             Display the help text
+    -s, --snippet          Do not include document headers/footers
+    -f, --fdx              Convert to Final Draft .fdx
+    -x, --xml              Output as the internal raw XML
+    -d, --diff             Assume input is a diff, generate revision marks
+    -w, --wrap             Wrap action and dialogue paragraphs
+    -e, --fheader          Look for fountain header and export it
+    -F, --fallback element Any untagged paragraph gets tagged as 'element'. Default is 'general'
 
 By default textplay converts to a fully-formed HTML document.
 
@@ -1060,13 +1066,8 @@ end
 
 # ------- Misc
 
-if options[:fdx] == true
-  # Any untagged paragraph gets tagged as 'general'
-  text = text.gsub(/^([^\n\<].*)/, '<general>\1</general>')
-else
-  # Any untagged paragraph gets tagged as 'action'
-  text = text.gsub(/^([^\n\<].*)/, '<action>\1</action>')
-end
+# Any untagged paragraph gets tagged as fallback_element
+text = text.gsub(/^([^\n\<].*)/, '<'+options[:fallback_element]+'>\1</'+options[:fallback_element]+'>')
 
 # Bold, Italic, Underline
 text = text.gsub(/(\()?\*{3}([^\*\n]+)\*{3}(\))?/, '<b><i>\1\2\3</i></b>')


### PR DESCRIPTION
This PR adds the command line option `-F, --fallback ELEMENT` that sets the fallback element type to be used on untagged paragraphs. The default value is `general`.

Implements part of the [card 2510](https://trello.com/c/NTRfZk95).